### PR TITLE
fix merge weights index

### DIFF
--- a/trinidi/cross_section.py
+++ b/trinidi/cross_section.py
@@ -187,8 +187,9 @@ class XSDict:
 
         for isotope in merge_isotopes:
             i = self.isotopes.index(isotope)
+            j = merge_isotopes.index(isotope)
 
-            d = d + D[i] * merge_weights[i]
+            d = d + D[i] * merge_weights[j]
             del D[i]
             del self.isotopes[i]
 


### PR DESCRIPTION
The index of merge_isotopes was not referring to the correct list, resulting in a wrong assignment

With the fix I can do this:

```python

from trinidi import cross_section
isotopes_full = ["U-238","U-235","W-180", "W-182", "W-183", "W-184", "W-186",
                "Xe-128","Xe-129","Xe-130","Xe-131","Xe-132","Xe-134","Xe-136",
                "Eu-151", "Au-197", "Ba-138", "Eu-153","Cs-133","Na-23","Cl-35","Cl-37","Eu-151","Eu-153"]

def register_isotope(D,name,isotopes):
    D.merge(list(isotopes.keys()),list(isotopes.values()),name)
    return D

                     
D_full = cross_section.XSDict(isotopes_full, t_F, 10.7)
D = register_isotope(D_full)
D = register_isotope(D,name="U",isotopes={"U-238":0.97,"U-235":0.03})
D = register_isotope(D,name="BaBrCl:EuAu",isotopes={"Eu-151":0.02,"Ba-138":0.3,"Eu-153":0.03,"Au-197":0.01})

```